### PR TITLE
Wencheng

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ jdk:
   - oraclejdk8
 addons:
   postgresql: "9.6"
+  srcclr: true
+before_install:
+  # Disable SourceClear except on scheduled builds
+  - |
+    if [ "$TRAVIS_EVENT_TYPE" != "cron" ]
+    then
+      export NOSCAN=1
+    fi
 before_script:
   - psql -U postgres -c "create user test with password 'test';"
   - psql -c 'create database test owner test;' -U postgres

--- a/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
@@ -47,7 +47,7 @@ public class BigQueryWriter<T> {
   private volatile CountDownLatch bqSchemaReady;
 
   volatile private Schema bgSchema;
-  private FieldList fields;
+//  private FieldList fields;
 
   private TableInfo tableInfo;
   private String[] entryIdFields;
@@ -57,7 +57,7 @@ public class BigQueryWriter<T> {
   private String dataset;
   private String[] columnNames;
   private int[] precisions;
-  private int[] scales;
+//  private int[] scales;
   private int[] columnTypes;
   private Map<String,String> labels;
 
@@ -142,8 +142,8 @@ public class BigQueryWriter<T> {
   private Table checkTable(BigQuery bigquery){
     TableId tableId = TableId.of(dataset, tableName);
     Table table = bigquery.getTable(tableId);
-    if(table!=null)
-      fields = Objects.requireNonNull(table.getDefinition().getSchema()).getFields();
+//    if(table!=null)
+//      fields = Objects.requireNonNull(table.getDefinition().getSchema()).getFields();
 
 
     log.info("checking table result:"+(table!=null?table.toString():null));
@@ -173,7 +173,7 @@ public class BigQueryWriter<T> {
       columnNames = SqlArgs.tidyColumnNames(columnNames);
       columnTypes = new int[columnCount];
       precisions = new int[columnCount];
-      scales = new int[columnCount];
+//      scales = new int[columnCount];
 
       for (int i = 0; i < columnCount; i++) {
         int columnType = metadata.getColumnType(i + 1);
@@ -206,7 +206,7 @@ public class BigQueryWriter<T> {
             int precision = metadata.getPrecision(i + 1);
             int scale = metadata.getScale(i + 1);
             precisions[i] = precision;
-            scales[i] = scale;
+//            scales[i] = scale;
             fieldType = LegacySQLTypeName.NUMERIC; //LegacySQLTypeName.BYTES
             break;
 
@@ -239,7 +239,7 @@ public class BigQueryWriter<T> {
       throw new DatabaseException("Unable to retrieve metadata from ResultSet", e);
     }
     bgSchema = com.google.cloud.bigquery.Schema.of(schemaFields);
-    fields = bgSchema.getFields();
+//    fields = bgSchema.getFields();
     return bgSchema;
   }
 
@@ -434,9 +434,9 @@ public class BigQueryWriter<T> {
   }
 
 
-  public synchronized com.google.auth.Credentials  getGoogleCredential(String credentialFile, List<String> scopes) throws IOException {
+  private synchronized com.google.auth.Credentials  getGoogleCredential(String credentialFile, List<String> scopes) throws IOException {
 
-    GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(credentialFile), new HttpTransportFactory() {
+    return GoogleCredentials.fromStream(new FileInputStream(credentialFile), new HttpTransportFactory() {
       @Override
       public HttpTransport create() {
         try {
@@ -448,7 +448,6 @@ public class BigQueryWriter<T> {
       }
     })
       .createScoped(scopes);
-    return credentials;
   }
 
 
@@ -551,7 +550,7 @@ public class BigQueryWriter<T> {
   }
 
 
-  public static final class BigQueryWriterBuilder {
+   static final class BigQueryWriterBuilder {
     String bigqueryProjectId;
     String googleCredentialFile;
     String[] entryIdFields;
@@ -564,51 +563,51 @@ public class BigQueryWriter<T> {
     private BigQueryWriterBuilder() {
     }
 
-    public static BigQueryWriterBuilder aBigQueryWriter() {
+    static BigQueryWriterBuilder aBigQueryWriter() {
       return new BigQueryWriterBuilder();
     }
 
-    public BigQueryWriterBuilder withBigqueryProjectId(String bigqueryProjectId) {
+    BigQueryWriterBuilder withBigqueryProjectId(String bigqueryProjectId) {
       this.bigqueryProjectId = bigqueryProjectId;
       return this;
     }
 
-    public BigQueryWriterBuilder withEntryIdFields(String[] entryIdFields) {
+    BigQueryWriterBuilder withEntryIdFields(String[] entryIdFields) {
       this.entryIdFields = entryIdFields;
       return this;
     }
 
-    public BigQueryWriterBuilder withUploadBatchSize(int uploadBatchSize) {
+    BigQueryWriterBuilder withUploadBatchSize(int uploadBatchSize) {
       this.uploadBatchSize = uploadBatchSize;
       return this;
     }
 
-    public BigQueryWriterBuilder withDataset(String dataset) {
+    BigQueryWriterBuilder withDataset(String dataset) {
       this.dataset = dataset;
       return this;
     }
 
-    public BigQueryWriterBuilder withTableName(String tableName) {
+    BigQueryWriterBuilder withTableName(String tableName) {
       this.tableName = tableName;
       return this;
     }
 
-    public BigQueryWriterBuilder withUploadThread(int uploadThread) {
+    BigQueryWriterBuilder withUploadThread(int uploadThread) {
       this.uploadThread = uploadThread;
       return this;
     }
 
-    public BigQueryWriterBuilder withBigQueryCredentialFile(String googleCredentialFile) {
+    BigQueryWriterBuilder withBigQueryCredentialFile(String googleCredentialFile) {
       this.googleCredentialFile = googleCredentialFile;
       return this;
     }
 
-    public BigQueryWriterBuilder withLabels(Map<String,String> labels){
+    BigQueryWriterBuilder withLabels(Map<String,String> labels){
       this.labels = labels;
       return this;
     }
 
-    public BigQueryWriter<Row> build() throws Exception {
+    BigQueryWriter<Row> build() throws Exception {
       BigQueryWriter<Row> bigQueryWriter = new BigQueryWriter<>();
       bigQueryWriter.bigqueryProjectId = this.bigqueryProjectId;
       bigQueryWriter.dataset = this.dataset;
@@ -617,7 +616,6 @@ public class BigQueryWriter<T> {
       bigQueryWriter.uploadThread = this.uploadThread;
       bigQueryWriter.entryIdFields = this.entryIdFields;
       bigQueryWriter.uploadBatchSize = this.uploadBatchSize;
-      bigQueryWriter.bigqueryProjectId = this.bigqueryProjectId;
       bigQueryWriter.labels = this.labels;
       return bigQueryWriter;
     }

--- a/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
@@ -392,9 +392,10 @@ public class BigQueryWriter<T> {
                 if(timeTook!=0) {
                   log.info("db " + tableName + " total:" + totalCnt.get() + " time " + timeTook
                       + " s speed:" + totalCnt.get() / totalTimeTook + " r/s");
-                }else {
-                  System.out.print("*");
                 }
+//                else {
+//                  System.out.print("*");
+//                }
 
                 lastBatchStartTs = Instant.now().getEpochSecond() ;
                 batchByteSize = 0;
@@ -405,7 +406,7 @@ public class BigQueryWriter<T> {
             if(uploadQueue.size()>uploadThread * 2){
               log.info("wait queue clear up");
               while(true) {
-                System.out.print("~"+uploadQueue.size());
+//                System.out.print("~"+uploadQueue.size());
                 Thread.sleep(2000);
                 if(uploadQueue.size()<=uploadThread * 2) {
                   break;
@@ -501,13 +502,13 @@ public class BigQueryWriter<T> {
                           try {
                               InsertAllResponse response = table.insert(payload);
 
-                                System.out.print("<");
+//                                System.out.print("<");
                               if(response.getInsertErrors().size()>0){
                                   log.error(response.getInsertErrors().toString());
                                   throw new Exception("BigQuery failed");
                               }else{
                                 lastId = payload.get(payload.size()-1).getId();
-                                System.out.print(workerId+">");
+//                                System.out.print(workerId+">");
                                 payload.clear();
 
                                 break;

--- a/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -192,6 +193,7 @@ public class BigQueryWriter<T> {
             fieldType = LegacySQLTypeName.INTEGER;
             break;
           case Types.REAL:
+          case Types.FLOAT:
           case 100: // Oracle proprietary it seems
             fieldType = LegacySQLTypeName.FLOAT;
             break;
@@ -264,6 +266,7 @@ public class BigQueryWriter<T> {
           row.put(columnNames[i], r.getFloatOrNull(columnNames[i]));
           break;
         case Types.DOUBLE:
+        case Types.FLOAT: //bigquery float is double precision
         case 101: // Oracle proprietary it seems
           row.put(columnNames[i], r.getDoubleOrNull(columnNames[i]));
           break;
@@ -273,7 +276,8 @@ public class BigQueryWriter<T> {
           BigDecimal v = r.getBigDecimalOrNull(columnNames[i]);
           if(v!=null){
             try{
-              row.put(columnNames[i],v);
+              // 9 decimal digits of scale allowed by BigQuery
+              row.put(columnNames[i],v.setScale(9, RoundingMode.HALF_UP));
             }catch (Exception e){
               row.put(columnNames[i], null);
             }

--- a/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
@@ -393,9 +393,6 @@ public class BigQueryWriter<T> {
                   log.info("db " + tableName + " total:" + totalCnt.get() + " time " + timeTook
                       + " s speed:" + totalCnt.get() / totalTimeTook + " r/s");
                 }
-//                else {
-//                  System.out.print("*");
-//                }
 
                 lastBatchStartTs = Instant.now().getEpochSecond() ;
                 batchByteSize = 0;
@@ -406,7 +403,6 @@ public class BigQueryWriter<T> {
             if(uploadQueue.size()>uploadThread * 2){
               log.info("wait queue clear up");
               while(true) {
-//                System.out.print("~"+uploadQueue.size());
                 Thread.sleep(2000);
                 if(uploadQueue.size()<=uploadThread * 2) {
                   break;
@@ -502,15 +498,12 @@ public class BigQueryWriter<T> {
                           try {
                               InsertAllResponse response = table.insert(payload);
 
-//                                System.out.print("<");
                               if(response.getInsertErrors().size()>0){
                                   log.error(response.getInsertErrors().toString());
                                   throw new Exception("BigQuery failed");
                               }else{
                                 lastId = payload.get(payload.size()-1).getId();
-//                                System.out.print(workerId+">");
                                 payload.clear();
-
                                 break;
                               }
                           }catch (Exception e){
@@ -551,7 +544,7 @@ public class BigQueryWriter<T> {
   }
 
 
-   static final class BigQueryWriterBuilder {
+   static final class Builder {
     String bigqueryProjectId;
     String googleCredentialFile;
     String[] entryIdFields;
@@ -561,49 +554,45 @@ public class BigQueryWriter<T> {
     int uploadThread;
     Map<String,String> labels;
 
-    private BigQueryWriterBuilder() {
+    public Builder() {
     }
 
-    static BigQueryWriterBuilder aBigQueryWriter() {
-      return new BigQueryWriterBuilder();
-    }
-
-    BigQueryWriterBuilder withBigqueryProjectId(String bigqueryProjectId) {
+    Builder withBigqueryProjectId(String bigqueryProjectId) {
       this.bigqueryProjectId = bigqueryProjectId;
       return this;
     }
 
-    BigQueryWriterBuilder withEntryIdFields(String[] entryIdFields) {
+    Builder withEntryIdFields(String[] entryIdFields) {
       this.entryIdFields = entryIdFields;
       return this;
     }
 
-    BigQueryWriterBuilder withUploadBatchSize(int uploadBatchSize) {
+    Builder withUploadBatchSize(int uploadBatchSize) {
       this.uploadBatchSize = uploadBatchSize;
       return this;
     }
 
-    BigQueryWriterBuilder withDataset(String dataset) {
+    Builder withDataset(String dataset) {
       this.dataset = dataset;
       return this;
     }
 
-    BigQueryWriterBuilder withTableName(String tableName) {
+    Builder withTableName(String tableName) {
       this.tableName = tableName;
       return this;
     }
 
-    BigQueryWriterBuilder withUploadThread(int uploadThread) {
+    Builder withUploadThread(int uploadThread) {
       this.uploadThread = uploadThread;
       return this;
     }
 
-    BigQueryWriterBuilder withBigQueryCredentialFile(String googleCredentialFile) {
+    Builder withBigQueryCredentialFile(String googleCredentialFile) {
       this.googleCredentialFile = googleCredentialFile;
       return this;
     }
 
-    BigQueryWriterBuilder withLabels(Map<String,String> labels){
+    Builder withLabels(Map<String,String> labels){
       this.labels = labels;
       return this;
     }

--- a/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/BigQueryWriter.java
@@ -279,7 +279,7 @@ public class BigQueryWriter<T> {
           }else if(v.scale()>9){
             try{
               row.put(columnNames[i],v.setScale(9, RoundingMode.HALF_UP));
-            }catch (Exception e){
+            }catch (ArithmeticException e){
               row.put(columnNames[i], null);
             }
           }else{

--- a/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
@@ -329,16 +329,16 @@ public final class Etl {
      * configure batch size of each BigQuery insert
      */
     @CheckReturnValue
-    SaveAsBigQuery bigQueryBatchSize(int batchSize) {
+    SaveAsBigQuery batchSize(int batchSize) {
       this.batchSize = batchSize;
       return this;
     }
 
     /**
-     * add labels to BigQuery table
+     * add labels to BigQuery table if table gets created in this run. The entire map will be replaced by the provided new map.
      */
     @CheckReturnValue
-    SaveAsBigQuery bigQueryLabel(Map<String, String> labels) {
+    SaveAsBigQuery bigQueryLabels(Map<String, String> labels) {
       this.labels = labels;
       return this;
     }

--- a/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
@@ -286,7 +286,7 @@ public final class Etl {
         }
 
         Map<String,String> labels= new HashMap<>();
-        labels.put("job","testing");
+
         BigQueryWriter<Row> bqWriter = BigQueryWriter.BigQueryWriterBuilder.aBigQueryWriter()
                 .withBigqueryProjectId(this.projectId)
                 .withDataset(this.datasetName)

--- a/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
@@ -345,7 +345,7 @@ public final class Etl {
      * add label in accumulative way
      */
     @CheckReturnValue
-    SaveAsBigQuery bigQueryLabel(String name, String value ) {
+    SaveAsBigQuery addLabel(String name, String value ) {
       if(this.labels == null){
         this.labels = new HashMap<>();
       }

--- a/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
@@ -261,7 +261,9 @@ public final class Etl {
     private final String entryIdFields;
     private final SqlSelect select;
     private int fetchSize = 100000;
-
+    private int workerNumber = 1;
+    private int batchSize = 500;
+    private Map<String, String> labels;
 
     SaveAsBigQuery(String projectId, String datasetName, String tableName, String entryIdFields, SqlSelect select) {
       this.projectId = projectId;
@@ -279,7 +281,9 @@ public final class Etl {
      * requres Google Client Credential file properly set up in env
      */
     public void start() throws Exception {
-      Map<String, String> labels = new HashMap<>();
+      if(this.labels == null){
+        labels = new HashMap<>();
+      }
 
       Optional<String> google_credential_file = Optional.ofNullable(System.getenv("GOOGLE_APPLICATION_CREDENTIALS")) ;
 
@@ -288,8 +292,8 @@ public final class Etl {
               .withDataset(this.datasetName)
               .withTableName(this.tableName)
               .withEntryIdFields(this.entryIdFields.split(","))
-              .withUploadBatchSize(500)
-              .withUploadThread(1)
+              .withUploadBatchSize(this.batchSize)
+              .withUploadThread(this.workerNumber)
               .withLabels(labels);
 
       google_credential_file.ifPresent(builder::withBigQueryCredentialFile);
@@ -308,9 +312,38 @@ public final class Etl {
      */
     @CheckReturnValue
     SaveAsBigQuery fetchSize(int nbrRows) {
-      fetchSize = nbrRows;
+      this.fetchSize = nbrRows;
       return this;
     }
+
+    /**
+     * configure number of upload workers
+     */
+    @CheckReturnValue
+    SaveAsBigQuery workerNumber(int workerNum) {
+      this.workerNumber = workerNum;
+      return this;
+    }
+
+    /**
+     * configure batch size of each BigQuery insert
+     */
+    @CheckReturnValue
+    SaveAsBigQuery bigQueryBatchSize(int batchSize) {
+      this.batchSize = batchSize;
+      return this;
+    }
+
+    /**
+     * add labels to BigQuery table
+     */
+    @CheckReturnValue
+    SaveAsBigQuery bigQueryLabel(Map<String, String> labels) {
+      this.labels = labels;
+      return this;
+    }
+
+
   }
 
 

--- a/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
@@ -337,7 +337,7 @@ public final class Etl {
      * add labels to BigQuery table if table gets created in this run. The entire map will be replaced by the provided new map.
      */
     @CheckReturnValue
-    SaveAsBigQuery bigQueryLabels(Map<String, String> labels) {
+    SaveAsBigQuery withLabels(Map<String, String> labels) {
       this.labels = labels;
       return this;
     }

--- a/src/test/java/com/github/susom/dbgoodies/etl/SaveAsBigQueryTest.java
+++ b/src/test/java/com/github/susom/dbgoodies/etl/SaveAsBigQueryTest.java
@@ -13,8 +13,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-import static org.junit.Assert.*;
-
 public class SaveAsBigQueryTest  {
 
     DatabaseProvider dbp;
@@ -56,7 +54,7 @@ public class SaveAsBigQueryTest  {
 
     @Test
     public void saveQuery() throws Exception {
-        Etl.saveQuery(db.toSelect("select * from dbtest")).asBigQuery("som-rit-phi-starr-miner-dev", "rit_clarity_note_non_phi", "dbtest", "id").fetchSize(10).bigQueryBatchSize(10).workerNumber(2).start();
+        Etl.saveQuery(db.toSelect("select * from dbtest")).asBigQuery("som-rit-phi-starr-miner-dev", "rit_clarity_note_non_phi", "dbtest", "id").fetchSize(10).batchSize(10).workerNumber(2).bigQueryLabel("creator","database-goodies unit test").start();
 
     }
 }

--- a/src/test/java/com/github/susom/dbgoodies/etl/SaveAsBigQueryTest.java
+++ b/src/test/java/com/github/susom/dbgoodies/etl/SaveAsBigQueryTest.java
@@ -54,7 +54,7 @@ public class SaveAsBigQueryTest  {
 
     @Test
     public void saveQuery() throws Exception {
-        Etl.saveQuery(db.toSelect("select * from dbtest")).asBigQuery("som-rit-phi-starr-miner-dev", "rit_clarity_note_non_phi", "dbtest", "id").fetchSize(10).batchSize(10).workerNumber(2).bigQueryLabel("creator","database-goodies unit test").start();
+        Etl.saveQuery(db.toSelect("select * from dbtest")).asBigQuery("som-rit-phi-starr-miner-dev", "rit_clarity_note_non_phi", "dbtest", "id").fetchSize(10).batchSize(10).workerNumber(2).addLabel("creator","database-goodies unit test").start();
 
     }
 }

--- a/src/test/java/com/github/susom/dbgoodies/etl/SaveAsBigQueryTest.java
+++ b/src/test/java/com/github/susom/dbgoodies/etl/SaveAsBigQueryTest.java
@@ -56,7 +56,7 @@ public class SaveAsBigQueryTest  {
 
     @Test
     public void saveQuery() throws Exception {
-        Etl.saveQuery(db.toSelect("select * from dbtest")).asBigQuery("som-rit-phi-starr-miner-dev", "rit_clarity_note_non_phi", "dbtest", "id").fetchSize(10).start();
+        Etl.saveQuery(db.toSelect("select * from dbtest")).asBigQuery("som-rit-phi-starr-miner-dev", "rit_clarity_note_non_phi", "dbtest", "id").fetchSize(10).bigQueryBatchSize(10).workerNumber(2).start();
 
     }
 }


### PR DESCRIPTION
allowing insertId as optional when insert to BigQuery. entryIdFields can be empty if duplicates are acceptable under network failure and retries.