### PR TITLE
Fixed jackson-bind(BIAR-65) and other vulnerabilities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,19 +235,30 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.5.4</version>
+      <version>3.6.0</version>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.8</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>3.5.4</version>
+      <version>3.6.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>3.5.4</version>
+      <version>3.6.0</version>
       <optional>true</optional>
     </dependency>
 
@@ -266,7 +277,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.5.4</version>
+      <version>3.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -279,11 +290,23 @@
      <groupId>org.apache.avro</groupId>
      <artifactId>avro</artifactId>
      <version>1.8.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.18</version>
+    </dependency>
+
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
-      <version>1.49.0</version>
+      <version>1.61.0</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
@garricko 

This PR contains the following vulnerability fixes.

- Jackson-databind
- Vertx version update
- Apache-commons
- Google-cloud-bigquery

Built this project and dependent projects successfully and the source clear risk score reduced from 78 to 55.

You can find the build logs in the following links.

**database-goodies:** 
[https://docs.google.com/document/d/1AhaplzR81WaVm2YZMkOddaAZGNCLBr0wrH9MjDnsA5s/edit](https://docs.google.com/document/d/1AhaplzR81WaVm2YZMkOddaAZGNCLBr0wrH9MjDnsA5s/edit)

[https://docs.google.com/document/d/1JUOHw3c-S-B6l64yfuHBN0nCIlkyoYQFS-qrESpXRfs/edit](https://docs.google.com/document/d/1JUOHw3c-S-B6l64yfuHBN0nCIlkyoYQFS-qrESpXRfs/edit)

**vertx-base:**
[https://docs.google.com/document/d/1l4_63j2E7RZOAkvqQz8fK5_Z_c-m6bxrdyEx0rm5J4c/edit](https://docs.google.com/document/d/1l4_63j2E7RZOAkvqQz8fK5_Z_c-m6bxrdyEx0rm5J4c/edit)

**vertx-parent:**
[https://docs.google.com/document/d/12NlQNujoUEvS8vgi93GJck10nA1OQ7L7XVdaCAZAGIU/edit](https://docs.google.com/document/d/12NlQNujoUEvS8vgi93GJck10nA1OQ7L7XVdaCAZAGIU/edit)

**mhealth:**
[https://docs.google.com/document/d/179a0FL6XnZW02xmzt-WFhj4J4mhMOEPYs8k6ESUztZk/edit](https://docs.google.com/document/d/179a0FL6XnZW02xmzt-WFhj4J4mhMOEPYs8k6ESUztZk/edit)

**vertx-template:**
[https://docs.google.com/document/d/1MV7UvZ188k4RZhA3JT2Y0J_keblW0ZIQ6yKlfXcek_Y/edit](https://docs.google.com/document/d/1MV7UvZ188k4RZhA3JT2Y0J_keblW0ZIQ6yKlfXcek_Y/edit)

[https://docs.google.com/document/d/15jP7fMHAxzrzT-Yq15EX6MUXQ8wyU19FVB_EigsqG7E/edit](https://docs.google.com/document/d/15jP7fMHAxzrzT-Yq15EX6MUXQ8wyU19FVB_EigsqG7E/edit)

[https://docs.google.com/document/d/1VOB28IXc74iGyQfD9SNUon4tt54r4iW9FaeRObK8uus/edit](https://docs.google.com/document/d/1VOB28IXc74iGyQfD9SNUon4tt54r4iW9FaeRObK8uus/edit)

Please review the PR and let us know your feedback.