### PR TITLE
STARR-2158 db-to-avro

### DIFF
--- a/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
+++ b/src/main/java/com/github/susom/dbgoodies/etl/Etl.java
@@ -564,6 +564,7 @@ public final class Etl {
                       org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(Type.NULL), org.apache.avro.Schema.create(Type.DOUBLE)),
                       null, Field.NULL_VALUE));
               break;
+            case Types.DECIMAL:
             case Types.NUMERIC:
               //These are the columns with NUMBER and FLOAT data types in Oracle
               //Specific data types are:
@@ -611,6 +612,7 @@ public final class Etl {
               break;
             case Types.BINARY:
             case Types.VARBINARY:
+            case Types.LONGVARBINARY:
             case Types.BLOB:
               fields.add(new org.apache.avro.Schema.Field(names[i],
                       org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(Type.NULL), org.apache.avro.Schema.create(Type.BYTES)),
@@ -645,6 +647,11 @@ public final class Etl {
                         org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(Type.NULL), org.apache.avro.Schema.create(Type.STRING)),
                         null, Field.NULL_VALUE));
               }
+              break;
+            case Types.BIT:
+              fields.add(new org.apache.avro.Schema.Field(names[i],
+                      org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(Type.NULL), org.apache.avro.Schema.create(Type.BOOLEAN)),
+                      null, Field.NULL_VALUE));
               break;
             default:
               throw new DatabaseException("Don't know how to deal with column type: " + types[i]);
@@ -681,6 +688,7 @@ public final class Etl {
           case 101: // Oracle proprietary it seems
             record.put(names[i], r.getDoubleOrNull());
             break;
+          case Types.DECIMAL:
           case Types.NUMERIC:
             //These are the columns with NUMBER and FLOAT data types in Oracle
             //Specific data types are:
@@ -724,6 +732,7 @@ public final class Etl {
             break;
           case Types.BINARY:
           case Types.VARBINARY:
+          case Types.LONGVARBINARY:
           case Types.BLOB:
             byte[] bytesOrNull = r.getBlobBytesOrNull();
             record.put(names[i], bytesOrNull == null ? null : ByteBuffer.wrap(bytesOrNull));
@@ -748,6 +757,9 @@ public final class Etl {
             } else {
               record.put(names[i], r.getStringOrNull());
             }
+            break;
+          case Types.BIT:
+            record.put(names[i], r.getBooleanOrNull());
             break;
           default:
             throw new DatabaseException("Don't know how to deal with column type: " + types[i]);


### PR DESCRIPTION
Multi-part Avro changes
- The Apache Avro writer has no method for returning the number of bytes written, so previously for splitting a file a maximum row-count was used. This left the responsibility to the caller of estimating how many rows were needed per Avro file.
  - In order to do the above, the caller needed to perform deep introspection on the database to get table size, row count, etc. These operations are slow, expensive, not portable, and error-prone from edge cases. 
  - In the end I decided to ditch the above method and instead simply sniff the size of the current file being written. This is only done once-per-second as it's expensive, however not nearly as expensive as deep DB introspection ended up being.
  - AFAIK only db-to-avro is using this method, so this is a breaking change.

Naming changes
- Avro files that end up never being split are named correctly (-000 is not appended)
- File multi-part naming is also simplified for clarity, %{PART} is no longer supported.

Data types:
- Added support for DECIMAL, LONG(N)VARCHAR, LONGVARBINARY, BIT, DATE 
  - Requires susom/database#28