### PR TITLE
Version fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.github.susom</groupId>
   <artifactId>database-goodies</artifactId>
   <packaging>jar</packaging>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.5-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Useful things built on top of the database library.</description>


### PR DESCRIPTION
Next version has to be 1.5 as the automated release process was accidentally triggered and created a v1.4 identical to v1.3. 

The v1.4 in Sonatype is benign and identical to v1.3.
